### PR TITLE
XCode11環境でpod repo pushが成功しないのを修正

### DIFF
--- a/leveldb_mirror.podspec
+++ b/leveldb_mirror.podspec
@@ -33,7 +33,8 @@ Pod::Spec.new do |s|
                else
                  "$(PODS_ROOT)/#{s.name}"
                end
-  s.pod_target_xcconfig = { "HEADER_SEARCH_PATHS" => "#{local_path}/leveldb" }
+  s.pod_target_xcconfig = { "HEADER_SEARCH_PATHS" => "#{local_path}/leveldb",
+                            "WARNING_CFLAGS" => "-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code -Wno-conditional-uninitialized -Wno-deprecated-declarations" }
   s.platforms = { :ios => "6.0", :osx => "10.7" }
   s.compiler_flags = "-DOS_MACOSX", "-DLEVELDB_PLATFORM_POSIX"
 end


### PR DESCRIPTION
Xcode11環境でのpod repo push時にpushが成功しない問題があったのを修正しました。

cocoapodsをXCode11対応のバージョン(v1.10.0.Beta.2)に上げる→ビルドエラー
--skip-import-validationオプションを追加→ビルドは成功するがpushが実行されない
本対応を追加→push成功

今回の対応はgoogleのleveldb公式パッケージのpodspecを参考にしました
https://github.com/CocoaPods/Specs/blob/master/Specs/a/d/a/leveldb-library/1.22/leveldb-library.podspec.json#L22